### PR TITLE
fix: used bootstrap modals and fixed the python version problem as well

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,3 @@ pytest-factoryboy = "*"
 
 [requires]
 python_version = "3.12"
-python_full_version = "3.12.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "082b7cbe98231dfcc2863a2f069959734643dc972924ccd1de52080c2da3cc5f"
+            "sha256": "658f1f1d31ef2521e5845fd5d18262df9bdfa2e10f1813bc008ee1de1623ed05"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_full_version": "3.12.10",
             "python_version": "3.12"
         },
         "sources": [
@@ -27,12 +26,12 @@
         },
         "django": {
             "hashes": [
-                "sha256:57fe1f1b59462caed092c80b3dd324fd92161b620d59a9ba9181c34746c97284",
-                "sha256:a9b680e84f9a0e71da83e399f1e922e1ab37b2173ced046b541c72e1589a5961"
+                "sha256:335213277666ab2c5cac44a792a6d2f3d58eb79a80c14b6b160cd4afc3b75684",
+                "sha256:c517a6334e0fd940066aa9467b29401b93c37cec2e61365d663b80922542069d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==5.2.1"
+            "version": "==5.2.3"
         },
         "django-environ": {
             "hashes": [
@@ -168,12 +167,12 @@
         },
         "django": {
             "hashes": [
-                "sha256:57fe1f1b59462caed092c80b3dd324fd92161b620d59a9ba9181c34746c97284",
-                "sha256:a9b680e84f9a0e71da83e399f1e922e1ab37b2173ced046b541c72e1589a5961"
+                "sha256:335213277666ab2c5cac44a792a6d2f3d58eb79a80c14b6b160cd4afc3b75684",
+                "sha256:c517a6334e0fd940066aa9467b29401b93c37cec2e61365d663b80922542069d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==5.2.1"
+            "version": "==5.2.3"
         },
         "django-debug-toolbar": {
             "hashes": [
@@ -233,14 +232,31 @@
             "markers": "python_version >= '3.9'",
             "version": "==1.6.0"
         },
+        "pygments": {
+            "hashes": [
+                "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
+                "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.19.1"
+        },
         "pytest": {
             "hashes": [
-                "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820",
-                "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"
+                "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6",
+                "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==8.4.0"
+        },
+        "pytest-django": {
+            "hashes": [
+                "sha256:1b63773f648aa3d8541000c26929c1ea63934be1cfa674c76436966d73fe6a10",
+                "sha256:a949141a1ee103cb0e7a20f1451d355f83f5e4a5d07bdd4dcfdd1fd0ff227991"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.3.5"
+            "version": "==4.11.1"
         },
         "pytest-factoryboy": {
             "hashes": [
@@ -261,11 +277,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c",
-                "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"
+                "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
+                "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.13.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.14.0"
         },
         "tzdata": {
             "hashes": [

--- a/templates/properties/detail.html
+++ b/templates/properties/detail.html
@@ -87,13 +87,32 @@
             {% endif %}
             {% if property.user == user %}
                 <a href="{% url 'properties:edit' property.pk %}" class="btn btn-warning">Edit Property</a>
-                <form method="post" action="{% url 'properties:delete' property.pk %}" style="display:inline;">
+                <form method="post" id="delete-form" action="{% url 'properties:delete' property.pk %}" style="display:inline;">
                     {% csrf_token %}
-                    <button type="submit" class="btn btn-danger" onclick="return confirm('Are you sure you want to delete this property?');">Delete Property</button>
+                    <button type="submit" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal">Delete Property</button>
                 </form>
             {% endif %}
             <a href="{% url 'properties:list' %}" class="btn btn-secondary">Back to Properties</a>
         </div>
     </div>
 </div>
+
+<!-- Confirm Delete Modal -->
+<div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-labelledby="confirmDeleteModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmDeleteModalLabel">Confirm Property Deletion</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          Are you sure you want to delete this property?
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-danger" form="delete-form">Yes, Delete</button>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/templates/users/password_change.html
+++ b/templates/users/password_change.html
@@ -10,7 +10,7 @@
             <div class="card shadow-sm">
                 <div class="card-body">
                     <h2 class="card-title text-center mb-4">Change Password</h2>
-                    <form method="post">
+                    <form method="post" id="password-form">
                         {% csrf_token %}
                         <div class="mb-3">
                             <label for="{{ form.old_password.id_for_label }}" class="form-label">{{ form.old_password.label }}</label>
@@ -40,12 +40,33 @@
                             {% endif %}
                         </div>
                         <div class="d-grid gap-2">
-                            <button type="submit" class="btn btn-primary" onclick="return confirm('Are you sure you want to change your password?')">Change Password</button>
-                        </div>
+                            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmPasswordModal">
+                                Change Password
+                            </button>
+                        </div>                        
                     </form>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
+<!-- Confirm Modal -->
+<div class="modal fade" id="confirmPasswordModal" tabindex="-1" aria-labelledby="confirmPasswordModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmPasswordModalLabel">Confirm Password Change</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          Are you sure you want to change your password?
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary" form="password-form">Yes, Change Password</button>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -10,7 +10,7 @@
             <div class="card shadow-sm">
                 <div class="card-body">
                     <h1 class="card-title text-center mb-4">Update Profile</h1>
-                    <form method="post">
+                    <form method="post" id="profile-form">
                         {% csrf_token %}
                         <div class="mb-3">
                             <label for="{{ form.username.id_for_label }}" class="form-label">{{ form.username.label }}</label>
@@ -49,14 +49,40 @@
                             {% endif %}
                         </div>
                         <div class="d-grid gap-2">
-                            <button type="submit" class="btn btn-primary" onclick="return confirm('Are you sure you want to update your profile?')">Update Profile</button>
+
+                            <!-- Trigger Modal Instead of Form Submission -->
+                            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmUpdateModal">
+                                Update Profile
+                            </button>
+                        
                             <a href="{% url 'users:logout' %}" class="btn btn-danger">Logout</a>
                             <a href="{% url 'users:change_password' %}" class="btn btn-outline-secondary">Change Password</a>
+                        
                         </div>
+                        
                     </form>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
+<!-- Confirm Update Modal -->
+<div class="modal fade" id="confirmUpdateModal" tabindex="-1" aria-labelledby="confirmUpdateModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmUpdateModalLabel">Confirm Profile Update</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          Are you sure you want to update your profile?
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary" form="profile-form">Yes, Update</button>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
This pull request introduces modal confirmation dialogs for critical user actions (deleting a property, changing a password, and updating a profile) to improve user experience and prevent accidental submissions. Additionally, a minor update was made to the `Pipfile`.

### User Experience Enhancements:

* **Property Deletion Confirmation**: Replaced the inline confirmation dialog with a Bootstrap modal for deleting properties. The modal provides a more modern and user-friendly confirmation mechanism. (`templates/properties/detail.html`, [templates/properties/detail.htmlL90-R117](diffhunk://#diff-2a7f40b3bda71b879a19caaf39fbd3e1d7c2605ad7ab5c9725ca3ceede9f4791L90-R117))
* **Password Change Confirmation**: Added a Bootstrap modal to confirm password changes, replacing the previous inline confirmation dialog. (`templates/users/password_change.html`, [templates/users/password_change.htmlL43-R71](diffhunk://#diff-2dbc0084f389809bef1f47b253883305332948c83ef1ed7973321e28ab30978cL43-R71))
* **Profile Update Confirmation**: Introduced a modal dialog for confirming profile updates, replacing the inline confirmation dialog. (`templates/users/profile.html`, [templates/users/profile.htmlL52-R87](diffhunk://#diff-40f7faefd30d053f0caedcda1146bde4b07f6b64e61036f3635505b99872c036L52-R87))

### Code Adjustments:

* **Form IDs**: Added unique IDs to forms (`delete-form`, `password-form`, `profile-form`) to associate them with their respective modal dialogs. (`templates/properties/detail.html`, [[1]](diffhunk://#diff-2a7f40b3bda71b879a19caaf39fbd3e1d7c2605ad7ab5c9725ca3ceede9f4791L90-R117); `templates/users/password_change.html`, [[2]](diffhunk://#diff-2dbc0084f389809bef1f47b253883305332948c83ef1ed7973321e28ab30978cL13-R13); `templates/users/profile.html`, [[3]](diffhunk://#diff-40f7faefd30d053f0caedcda1146bde4b07f6b64e61036f3635505b99872c036L13-R13)

### Miscellaneous:

* **`Pipfile` Update**: Removed the `python_full_version` specification, likely to allow greater flexibility in Python versioning. (`Pipfile`, [PipfileL21](diffhunk://#diff-230078d672f10d17463a8a6265cad825b790885898256a3365be90685caac58dL21))