### PR TITLE
fix: static files fixed

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -76,7 +76,9 @@ USE_I18N = True
 USE_TZ = True
 
 STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_DIRS = [BASE_DIR / "static"]
+
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 


### PR DESCRIPTION
This pull request makes a small change to the `config/settings.py` file by adding the `STATIC_ROOT` setting to specify the directory for collecting static files during deployment.

* [`config/settings.py`](diffhunk://#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193R79-R81): Added `STATIC_ROOT` to define the directory (`BASE_DIR / "staticfiles"`) where static files will be collected.