### PR TITLE
feat(admin): Integrate django-unfold for enhanced admin interface

### DIFF
--- a/apps/properties/views.py
+++ b/apps/properties/views.py
@@ -5,23 +5,19 @@ All interactive functionality is handled by HTMX and Alpine.js.
 
 import logging
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.paginator import Paginator
-from django.http import Http404, JsonResponse
-from django.shortcuts import get_object_or_404, redirect, render
-from apps.properties.utils import delete_property_and_assets
-
-from apps.properties.models import Favorite, Property, PropertyImage
-from apps.properties.utils import handle_document_download
-from apps.properties.forms import PropertyForm
-from django.contrib import messages
 from django.db import transaction
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from apps.properties.validations import phone_validator, cnic_validator
 
-
+from apps.properties.forms import PropertyForm
+from apps.properties.models import Favorite, Property, PropertyImage
+from apps.properties.utils import delete_property_and_assets, handle_document_download
+from apps.properties.validations import cnic_validator, phone_validator
 
 logger = logging.getLogger(__name__)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import dj_database_url
 from django.contrib import messages
+from django.templatetags.static import static
 from environs import Env
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -33,6 +34,7 @@ CSRF_TRUSTED_ORIGINS = [
 ]
 
 INSTALLED_APPS = [
+    "unfold",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -195,6 +197,35 @@ LOGGING = {
             "handlers": ["console"],
             "level": "INFO",
             "propagate": False,
+        },
+    },
+}
+
+UNFOLD = {
+    "SITE_TITLE": "PropertyHub Admin",
+    "SITE_HEADER": "PropertyHub",
+    "SHOW_HISTORY": True,
+    "SHOW_VIEW_ON_SITE": True,
+    "SITE_FAVICONS": [
+        {
+            "rel": "icon",
+            "sizes": "32x32",
+            "type": "image/svg+xml",
+            "href": lambda request: static("images/favicon.svg"),
+        },
+    ],
+    "COLORS": {
+        "primary": {
+            "50": "250 245 255",
+            "100": "243 244 255",
+            "200": "216 207 255",
+            "300": "192 190 255",
+            "400": "165 155 255",
+            "500": "139 122 255",
+            "600": "120 84 255",
+            "700": "102 58 255",
+            "800": "85 36 255",
+            "900": "70 13 255",
         },
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "psycopg[binary]>=3.2.10",
     "werkzeug>=3.1.3",
     "environs[django]>=14.5.0",
+    "django-unfold>=0.78.0",
 ]
 
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -227,6 +227,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-unfold"
+version = "0.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/ad/af07a81930a063f5153c56d74468a953b220bde8b0265a75f06e3d4e1172/django_unfold-0.78.0.tar.gz", hash = "sha256:07bae46c0e3be9c24d8d2970cba2b16f02cc83761bfd6c1f54418da237b12b30", size = 1109489, upload-time = "2026-02-02T08:35:28Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/eb/c34069a7e1b46c439da1868ef29b04edfbec1640e867b304492637ffdff6/django_unfold-0.78.0-py3-none-any.whl", hash = "sha256:dbf4ebaab2ac16d364b6eef449f09a8b618e9a11e57e580d458e9247a6a560e2", size = 1224843, upload-time = "2026-02-02T08:35:26.837Z" },
+]
+
+[[package]]
 name = "environs"
 version = "14.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -445,6 +457,7 @@ dependencies = [
     { name = "django-axes" },
     { name = "django-extensions" },
     { name = "django-storages" },
+    { name = "django-unfold" },
     { name = "environs", extra = ["django"] },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
@@ -470,6 +483,7 @@ requires-dist = [
     { name = "django-axes", specifier = ">=8.0.0" },
     { name = "django-extensions", specifier = ">=4.1" },
     { name = "django-storages", specifier = ">=1.14.6" },
+    { name = "django-unfold", specifier = ">=0.78.0" },
     { name = "environs", extras = ["django"], specifier = ">=14.5.0" },
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.10" },


### PR DESCRIPTION
- Add django-unfold package to project dependencies
- Configure Unfold admin theme with PropertyHub branding
- Set custom site title, header, and favicon configuration
- Implement purple color scheme for admin interface
- Enable history tracking and view-on-site functionality
- Standardize import ordering in properties views module
- Add static template tag import to settings configuration