### PR TITLE
feat: add seed_local management command for populating local development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# RealmKey - Agent Guide
+# Strata - Agent Guide
 
-This document provides AI agents with essential context for making informed decisions when working on the RealmKey codebase. It includes technology stack documentation, implementation patterns, and references to detailed project documentation.
+This document provides AI agents with essential context for making informed decisions when working on the Strata codebase. It includes technology stack documentation, implementation patterns, and references to detailed project documentation.
 
 ---
 
@@ -63,7 +63,7 @@ All implementation details are documented in the `docs/` directory:
 ## Project Structure
 
 ```
-realm-key/
+grid/
 ├── apps/                    # Django applications
 │   ├── properties/         # Property listings & management
 │   ├── users/              # Authentication & profiles

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,4 +1,4 @@
-# RealmKey
+# Strata
 
 Server-rendered Django + HTMX real-estate platform. Property listings, owner profiles, real-time chat between buyers and owners. No public REST API; all interaction is through HTML responses and WebSocket events.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-# Contributing to RealmKey
+# Contributing to Strata
 
-Thank you for your interest in contributing to RealmKey! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to Strata! This document provides guidelines and instructions for contributing.
 
 ## Getting Started
 
 1. **Fork the repository**
 2. **Clone your fork**
    ```bash
-   git clone https://github.com/your-username/realm-key.git
-   cd realm-key
+   git clone https://github.com/your-username/strata.git
+   cd strata
    ```
 3. **Set up development environment**
    - Follow the [README.md](../README.md) setup instructions
@@ -446,4 +446,4 @@ If you have questions about contributing:
 3. Open a GitHub Discussion
 4. Ask in project communication channels
 
-Thank you for contributing to RealmKey! 🎉
+Thank you for contributing to Strata! 🎉

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RealmKey
+# Strata
 
 A modern real-estate property management platform built with Django, featuring a component-based architecture for listing, searching, and managing properties.
 
@@ -48,7 +48,7 @@ Comprehensive documentation is available in the [`docs/`](./docs/) directory:
 ### Project Structure
 
 ```
-realm-key/
+grid/
 ├── apps/
 │   ├── properties/          # Property management
 │   │   ├── models.py        # Property, PropertyImage models
@@ -124,7 +124,7 @@ realm-key/
 1. **Clone the repository**
    ```bash
    git clone <repository-url>
-   cd realm-key
+   cd strata
    ```
 
 2. **Set up environment variables**
@@ -233,7 +233,7 @@ In Progress
 
 **Quick Deploy:**
 ```bash
-docker build -t realm-key .
+docker build -t strata .
 docker-compose -f docker-compose.prod.yml up
 ```
 

--- a/apps/chat/templates/chat/conversation_detail.html
+++ b/apps/chat/templates/chat/conversation_detail.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/base.html' %}
 {% load static %}
 
-{% block title %}Chat with {{ other_participant.email }} - RealmKey{% endblock %}
+{% block title %}Chat with {{ other_participant.email }} - Strata{% endblock %}
 
 {% block extra_head %}
 <script src="{% static 'js/chat-client.js' %}"></script>

--- a/apps/chat/templates/chat/conversation_list.html
+++ b/apps/chat/templates/chat/conversation_list.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/base.html' %}
 {% load static %}
 
-{% block title %}My Conversations - RealmKey{% endblock %}
+{% block title %}My Conversations - Strata{% endblock %}
 
 {% block content %}
 <div class="max-w-5xl mx-auto">

--- a/apps/properties/templates/properties/create.html
+++ b/apps/properties/templates/properties/create.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/base.html' %}
 {% load static %}
 
-{% block title %}Add Property - RealmKey{% endblock %}
+{% block title %}Add Property - Strata{% endblock %}
 
 {% block content %}
 <div class="max-w-5xl mx-auto">

--- a/apps/properties/templates/properties/detail.html
+++ b/apps/properties/templates/properties/detail.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/base.html' %}
 {% load static %}
 
-{% block title %}{{ property.name }} - RealmKey{% endblock %}
+{% block title %}{{ property.name }} - Strata{% endblock %}
 
 {% block content %}
 <div class="max-w-7xl mx-auto">
@@ -74,7 +74,7 @@
         {% endif %}
     </div>
 
-    <!-- Property Details Grid -->
+    <!-- Property Details -->
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <!-- Main Content -->
         <div class="lg:col-span-2 space-y-8">

--- a/apps/properties/templates/properties/edit.html
+++ b/apps/properties/templates/properties/edit.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/base.html' %}
 {% load static %}
 
-{% block title %}Edit {{ property.name }} - RealmKey{% endblock %}
+{% block title %}Edit {{ property.name }} - Strata{% endblock %}
 
 {% block content %}
 <div class="max-w-4xl mx-auto">

--- a/apps/properties/templates/properties/favorites.html
+++ b/apps/properties/templates/properties/favorites.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/base.html' %}
 {% load static %}
 
-{% block title %}My Favorites - RealmKey{% endblock %}
+{% block title %}My Favorites - Strata{% endblock %}
 
 {% block content %}
 <div x-data="{
@@ -47,7 +47,7 @@
         </div>
     </div>
 
-    <!-- Properties Grid -->
+    <!-- Properties -->
     <div x-show="favoriteCount > 0">
         {% if properties %}
             {% include 'properties/partials/property_grid.html' with properties=properties page_obj=page_obj %}

--- a/apps/properties/templates/properties/list.html
+++ b/apps/properties/templates/properties/list.html
@@ -3,11 +3,11 @@
 
 {% block title %}
     {% if show_my_properties %}
-        My Properties - RealmKey
+        My Properties - Strata
     {% elif show_favorites %}
-        Favorites - RealmKey
+        Favorites - Strata
     {% else %}
-        Properties - RealmKey
+        Properties - Strata
     {% endif %}
 {% endblock %}
 
@@ -118,7 +118,7 @@
         </div>
     {% endif %}
 
-    <!-- Properties Grid -->
+    <!-- Properties -->
     {% include 'properties/partials/property_grid.html' with properties=properties page_obj=page_obj %}
 </div>
 

--- a/apps/properties/templates/properties/my-properties.html
+++ b/apps/properties/templates/properties/my-properties.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/dashboard.html' %}
 {% load static %}
 
-{% block title %}My Properties - RealmKey{% endblock %}
+{% block title %}My Properties - Strata{% endblock %}
 
 {% block page_title %}My Properties{% endblock %}
 
@@ -80,7 +80,7 @@
         </div>
     </div>
 
-    <!-- Properties Grid -->
+    <!-- Properties -->
     <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
         {% for property in properties %}
             <div class="card bg-base-100 shadow-soft hover:shadow-large transition-all duration-300">

--- a/apps/properties/templates/properties/partials/property_detail.html
+++ b/apps/properties/templates/properties/partials/property_detail.html
@@ -23,7 +23,7 @@
         {% endif %}
     </div>
 
-    <!-- Property Details Grid -->
+    <!-- Property Details -->
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <!-- Main Content -->
         <div class="lg:col-span-2 space-y-8">

--- a/apps/shared/management/commands/seed_local.py
+++ b/apps/shared/management/commands/seed_local.py
@@ -1,17 +1,17 @@
 import random
-from io import BytesIO
 from decimal import Decimal
+from io import BytesIO
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from PIL import Image, ImageDraw
 
 try:
+    from PIL import Image, ImageDraw
     from faker import Faker
-except ImportError as exc:  # pragma: no cover - exercised only without dev deps
-    raise CommandError(
+except ImportError as exc:  # pragma: no cover - dependency guard
+    raise ImportError(
         "The seed_local command requires dev dependencies. "
         "Install them with `uv sync --group dev`."
     ) from exc
@@ -30,22 +30,27 @@ from apps.users.services import user_create
 User = get_user_model()
 
 SEED_EMAIL_DOMAIN = "strata.local"
-DEFAULT_PASSWORD = "RealmPass1!"
+SEED_EMAIL_SUFFIX = f"@{SEED_EMAIL_DOMAIN}"
+DEFAULT_PASSWORD = "StrataPass1!"
 PROPERTY_TYPES = ("House", "Plot")
 IMAGE_PALETTES = (
-    ((235, 238, 230), (90, 118, 88), (189, 171, 138)),
-    ((229, 235, 240), (61, 86, 107), (180, 156, 121)),
-    ((237, 232, 224), (124, 86, 66), (75, 104, 111)),
-    ((228, 237, 233), (70, 101, 82), (194, 151, 95)),
+    ((228, 217, 201), (125, 99, 84), (181, 154, 132)),
+    ((209, 224, 232), (88, 111, 125), (146, 167, 178)),
+    ((223, 218, 200), (92, 96, 80), (155, 160, 134)),
+    ((232, 212, 196), (132, 94, 76), (195, 150, 125)),
 )
 CHAT_SNIPPETS = (
     "Hi, is this property still available?",
     "Yes, it is available. Would you like to schedule a visit?",
-    "Could you share more details about the neighborhood?",
-    "The area is quiet and close to schools, shops, and public transport.",
-    "Is the price negotiable?",
-    "There is some room for negotiation after a viewing.",
+    "That sounds good. Is there any flexibility on the price?",
+    "There may be some room depending on timing and payment terms.",
+    "Great, thanks. Can you share more details about the neighborhood?",
+    "Absolutely. It is a quiet area with easy access to schools and shops.",
 )
+
+
+def seeded_user_queryset():
+    return User.objects.filter(email__endswith=SEED_EMAIL_SUFFIX)
 
 
 class Command(BaseCommand):
@@ -102,18 +107,17 @@ class Command(BaseCommand):
         parser.add_argument(
             "--reset",
             action="store_true",
-            help=f"Delete existing @{SEED_EMAIL_DOMAIN} seed users before seeding.",
+            help=f"Delete existing {SEED_EMAIL_SUFFIX} seed users before seeding.",
         )
         parser.add_argument(
             "--delete",
             action="store_true",
-            help=f"Delete existing @{SEED_EMAIL_DOMAIN} seed users and exit.",
+            help=f"Delete existing {SEED_EMAIL_SUFFIX} seed users and exit.",
         )
 
     @transaction.atomic
     def handle(self, *args, **options):
         self._validate_counts(options)
-
         random.seed(options["random_seed"])
         fake = Faker()
         Faker.seed(options["random_seed"])
@@ -131,7 +135,7 @@ class Command(BaseCommand):
             return
 
         admin = self._ensure_user(
-            email=f"admin@{SEED_EMAIL_DOMAIN}",
+            email=f"admin{SEED_EMAIL_SUFFIX}",
             first_name="Strata",
             last_name="Admin",
             password=options["password"],
@@ -167,37 +171,29 @@ class Command(BaseCommand):
                 "Seeded local data: "
                 f"users={len(users) + 1}, "
                 f"properties={len(properties)}, "
-                f"favorites={Favorite.objects.filter(user__email__endswith=SEED_EMAIL_DOMAIN).count()} "
-                f"({favorites_created} new), "
+                f"favorites={Favorite.objects.filter(user__email__endswith=SEED_EMAIL_SUFFIX).count()} "
+                f"(created {favorites_created}), "
                 f"conversations={len(conversations)}, "
-                f"messages={messages_created} new, "
-                f"images={sum(prop.images.count() for prop in properties)}."
+                f"messages={Message.objects.filter(conversation__in=conversations).count()} "
+                f"(created {messages_created})"
             )
-        )
-        self.stdout.write(
-            f"Demo login: admin@{SEED_EMAIL_DOMAIN} / {options['password']}"
         )
 
     def _validate_counts(self, options):
-        for name in (
+        count_options = (
             "users",
             "properties",
             "favorites",
             "conversations",
             "messages",
             "images",
-        ):
-            if options[name] < 0:
-                raise CommandError(f"--{name} must be greater than or equal to 0.")
-        if options["reset"] and options["delete"]:
-            raise CommandError("Use either --reset or --delete, not both.")
-        if options["properties"] > 0 and options["users"] == 0:
-            raise CommandError("--properties requires at least one seeded user.")
-        if options["conversations"] > 0 and options["users"] < 2:
-            raise CommandError("--conversations requires at least two seeded users.")
+        )
+        for option_name in count_options:
+            if options[option_name] < 0:
+                raise CommandError(f"--{option_name.replace('_', '-')} must be >= 0.")
 
     def _reset_seed_data(self):
-        queryset = User.objects.filter(email__endswith=SEED_EMAIL_DOMAIN)
+        queryset = seeded_user_queryset()
         count = queryset.count()
         queryset.delete()
         return count
@@ -205,7 +201,7 @@ class Command(BaseCommand):
     def _ensure_users(self, *, count, password, fake):
         return [
             self._ensure_user(
-                email=f"user{index}@{SEED_EMAIL_DOMAIN}",
+                email=f"user{index}{SEED_EMAIL_SUFFIX}",
                 first_name=fake.first_name(),
                 last_name=fake.last_name(),
                 password=password,
@@ -214,7 +210,13 @@ class Command(BaseCommand):
         ]
 
     def _ensure_user(
-        self, *, email, first_name, last_name, password, is_superuser=False
+        self,
+        *,
+        email,
+        first_name,
+        last_name,
+        password,
+        is_superuser=False,
     ):
         user = User.objects.filter(email=email).first()
         if user is None:
@@ -240,10 +242,11 @@ class Command(BaseCommand):
     def _ensure_properties(self, *, count, owners, fake):
         properties = list(
             Property.objects.filter(
-                user__email__endswith=SEED_EMAIL_DOMAIN,
+                user__email__endswith=SEED_EMAIL_SUFFIX,
                 name__startswith="Seed Property ",
             ).order_by("id")[:count]
         )
+
         for index in range(len(properties) + 1, count + 1):
             owner = owners[(index - 1) % len(owners)]
             property_type = random.choice(PROPERTY_TYPES)
@@ -268,8 +271,10 @@ class Command(BaseCommand):
                 "is_published": random.random() > 0.15,
             }
             images = [
-                self._generate_property_image(property_index=index, image_index=image)
-                for image in range(1, self._images_per_property + 1)
+                self._generate_property_image(
+                    property_index=index, image_index=image_index
+                )
+                for image_index in range(1, self._images_per_property + 1)
             ]
             try:
                 properties.append(
@@ -277,41 +282,34 @@ class Command(BaseCommand):
                 )
             except ApplicationError as exc:
                 raise CommandError(exc.message) from exc
+
         for property_obj in properties:
             self._ensure_property_images(property_obj=property_obj)
+
         return properties
 
     def _ensure_property_images(self, *, property_obj):
-        existing_count = property_obj.images.count()
-        for image_index in range(existing_count + 1, self._images_per_property + 1):
+        missing_images = max(0, self._images_per_property - property_obj.images.count())
+        for offset in range(1, missing_images + 1):
+            image = self._generate_property_image(
+                property_index=property_obj.id,
+                image_index=property_obj.images.count() + offset,
+            )
             property_image_add(
                 property_obj=property_obj,
-                image_file=self._generate_property_image(
-                    property_index=property_obj.id,
-                    image_index=image_index,
-                ),
-                is_primary=(existing_count == 0 and image_index == 1),
+                image_file=image,
+                is_primary=(property_obj.images.count() == 0),
             )
 
     def _generate_property_image(self, *, property_index, image_index):
         width, height = 1200, 800
-        background, accent, secondary = IMAGE_PALETTES[
-            (property_index + image_index) % len(IMAGE_PALETTES)
-        ]
-        image = Image.new("RGB", (width, height), background)
+        background, secondary, accent = random.choice(IMAGE_PALETTES)
+        image = Image.new("RGB", (width, height), color=background)
         draw = ImageDraw.Draw(image)
+        horizon = 430
 
-        horizon = height // 2 + random.randint(-45, 45)
-        draw.rectangle((0, horizon, width, height), fill=(214, 218, 204))
         draw.rectangle((0, 0, width, horizon), fill=background)
-        draw.polygon(
-            (
-                (220, horizon),
-                (600, 180),
-                (980, horizon),
-            ),
-            fill=accent,
-        )
+        draw.polygon(((220, horizon), (600, 180), (980, horizon)), fill=accent)
         draw.rectangle((315, horizon - 20, 885, 625), fill=(246, 242, 232))
         draw.rectangle((395, 420, 520, 625), fill=secondary)
         draw.rectangle((610, 410, 795, 525), fill=(178, 204, 216))
@@ -335,7 +333,7 @@ class Command(BaseCommand):
         attempts = 0
         max_attempts = max(count * 10, 25)
         while (
-            Favorite.objects.filter(user__email__endswith=SEED_EMAIL_DOMAIN).count()
+            Favorite.objects.filter(user__email__endswith=SEED_EMAIL_SUFFIX).count()
             < count
             and attempts < max_attempts
         ):
@@ -356,8 +354,8 @@ class Command(BaseCommand):
 
         conversations = list(
             Conversation.objects.filter(
-                participant_one__email__endswith=SEED_EMAIL_DOMAIN,
-                participant_two__email__endswith=SEED_EMAIL_DOMAIN,
+                participant_one__email__endswith=SEED_EMAIL_SUFFIX,
+                participant_two__email__endswith=SEED_EMAIL_SUFFIX,
             ).order_by("id")[:count]
         )
         attempts = 0
@@ -382,7 +380,10 @@ class Command(BaseCommand):
         for conversation in conversations:
             existing_count = conversation.messages.count()
             missing_count = max(0, messages_per_conversation - existing_count)
-            participants = (conversation.participant_one, conversation.participant_two)
+            participants = (
+                conversation.participant_one,
+                conversation.participant_two,
+            )
             for index in range(missing_count):
                 sender = participants[(existing_count + index) % 2]
                 content = CHAT_SNIPPETS[(existing_count + index) % len(CHAT_SNIPPETS)]
@@ -392,7 +393,9 @@ class Command(BaseCommand):
                     content=content,
                 )
                 created += 1
+
             Message.objects.filter(conversation=conversation).exclude(
                 sender=conversation.participant_two
             ).update(is_read=True)
+
         return created

--- a/apps/shared/management/commands/seed_local.py
+++ b/apps/shared/management/commands/seed_local.py
@@ -29,7 +29,7 @@ from apps.users.services import user_create
 
 User = get_user_model()
 
-SEED_EMAIL_DOMAIN = "realmkey.local"
+SEED_EMAIL_DOMAIN = "strata.local"
 DEFAULT_PASSWORD = "RealmPass1!"
 PROPERTY_TYPES = ("House", "Plot")
 IMAGE_PALETTES = (
@@ -49,7 +49,7 @@ CHAT_SNIPPETS = (
 
 
 class Command(BaseCommand):
-    help = "Seed local development data for RealmKey."
+    help = "Seed local development data for Strata."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -132,7 +132,7 @@ class Command(BaseCommand):
 
         admin = self._ensure_user(
             email=f"admin@{SEED_EMAIL_DOMAIN}",
-            first_name="RealmKey",
+            first_name="Strata",
             last_name="Admin",
             password=options["password"],
             is_superuser=True,

--- a/apps/shared/management/commands/seed_local.py
+++ b/apps/shared/management/commands/seed_local.py
@@ -1,0 +1,398 @@
+import random
+from io import BytesIO
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from PIL import Image, ImageDraw
+
+try:
+    from faker import Faker
+except ImportError as exc:  # pragma: no cover - exercised only without dev deps
+    raise CommandError(
+        "The seed_local command requires dev dependencies. "
+        "Install them with `uv sync --group dev`."
+    ) from exc
+
+from apps.chat.models import Conversation, Message
+from apps.chat.services import conversation_start, message_create
+from apps.properties.models import Favorite, Property
+from apps.properties.services import (
+    favorite_toggle,
+    property_create,
+    property_image_add,
+)
+from apps.shared.exceptions import ApplicationError
+from apps.users.services import user_create
+
+User = get_user_model()
+
+SEED_EMAIL_DOMAIN = "realmkey.local"
+DEFAULT_PASSWORD = "RealmPass1!"
+PROPERTY_TYPES = ("House", "Plot")
+IMAGE_PALETTES = (
+    ((235, 238, 230), (90, 118, 88), (189, 171, 138)),
+    ((229, 235, 240), (61, 86, 107), (180, 156, 121)),
+    ((237, 232, 224), (124, 86, 66), (75, 104, 111)),
+    ((228, 237, 233), (70, 101, 82), (194, 151, 95)),
+)
+CHAT_SNIPPETS = (
+    "Hi, is this property still available?",
+    "Yes, it is available. Would you like to schedule a visit?",
+    "Could you share more details about the neighborhood?",
+    "The area is quiet and close to schools, shops, and public transport.",
+    "Is the price negotiable?",
+    "There is some room for negotiation after a viewing.",
+)
+
+
+class Command(BaseCommand):
+    help = "Seed local development data for RealmKey."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--users",
+            type=int,
+            default=8,
+            help="Number of non-admin demo users to ensure.",
+        )
+        parser.add_argument(
+            "--properties",
+            type=int,
+            default=12,
+            help="Number of demo properties to ensure.",
+        )
+        parser.add_argument(
+            "--favorites",
+            type=int,
+            default=16,
+            help="Number of demo favorites to ensure.",
+        )
+        parser.add_argument(
+            "--conversations",
+            type=int,
+            default=6,
+            help="Number of demo conversations to ensure.",
+        )
+        parser.add_argument(
+            "--messages",
+            type=int,
+            default=4,
+            help="Messages to ensure per demo conversation.",
+        )
+        parser.add_argument(
+            "--images",
+            type=int,
+            default=2,
+            help="Images to ensure per demo property.",
+        )
+        parser.add_argument(
+            "--password",
+            default=DEFAULT_PASSWORD,
+            help="Password assigned to every seeded user.",
+        )
+        parser.add_argument(
+            "--random-seed",
+            type=int,
+            default=42,
+            help="Random seed used for repeatable local data.",
+        )
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help=f"Delete existing @{SEED_EMAIL_DOMAIN} seed users before seeding.",
+        )
+        parser.add_argument(
+            "--delete",
+            action="store_true",
+            help=f"Delete existing @{SEED_EMAIL_DOMAIN} seed users and exit.",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        self._validate_counts(options)
+
+        random.seed(options["random_seed"])
+        fake = Faker()
+        Faker.seed(options["random_seed"])
+        self._images_per_property = options["images"]
+
+        if options["reset"]:
+            deleted = self._reset_seed_data()
+            self.stdout.write(f"Deleted {deleted} existing seeded user(s).")
+
+        if options["delete"]:
+            deleted = self._reset_seed_data()
+            self.stdout.write(
+                self.style.SUCCESS(f"Deleted {deleted} existing seeded user(s).")
+            )
+            return
+
+        admin = self._ensure_user(
+            email=f"admin@{SEED_EMAIL_DOMAIN}",
+            first_name="RealmKey",
+            last_name="Admin",
+            password=options["password"],
+            is_superuser=True,
+        )
+        users = self._ensure_users(
+            count=options["users"],
+            password=options["password"],
+            fake=fake,
+        )
+        properties = self._ensure_properties(
+            count=options["properties"],
+            owners=users[: max(1, len(users) // 3)] or [admin],
+            fake=fake,
+        )
+        favorites_created = self._ensure_favorites(
+            count=options["favorites"],
+            users=users,
+            properties=properties,
+        )
+        conversations = self._ensure_conversations(
+            count=options["conversations"],
+            users=users,
+            properties=properties,
+        )
+        messages_created = self._ensure_messages(
+            conversations=conversations,
+            messages_per_conversation=options["messages"],
+        )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Seeded local data: "
+                f"users={len(users) + 1}, "
+                f"properties={len(properties)}, "
+                f"favorites={Favorite.objects.filter(user__email__endswith=SEED_EMAIL_DOMAIN).count()} "
+                f"({favorites_created} new), "
+                f"conversations={len(conversations)}, "
+                f"messages={messages_created} new, "
+                f"images={sum(prop.images.count() for prop in properties)}."
+            )
+        )
+        self.stdout.write(
+            f"Demo login: admin@{SEED_EMAIL_DOMAIN} / {options['password']}"
+        )
+
+    def _validate_counts(self, options):
+        for name in (
+            "users",
+            "properties",
+            "favorites",
+            "conversations",
+            "messages",
+            "images",
+        ):
+            if options[name] < 0:
+                raise CommandError(f"--{name} must be greater than or equal to 0.")
+        if options["reset"] and options["delete"]:
+            raise CommandError("Use either --reset or --delete, not both.")
+        if options["properties"] > 0 and options["users"] == 0:
+            raise CommandError("--properties requires at least one seeded user.")
+        if options["conversations"] > 0 and options["users"] < 2:
+            raise CommandError("--conversations requires at least two seeded users.")
+
+    def _reset_seed_data(self):
+        queryset = User.objects.filter(email__endswith=SEED_EMAIL_DOMAIN)
+        count = queryset.count()
+        queryset.delete()
+        return count
+
+    def _ensure_users(self, *, count, password, fake):
+        return [
+            self._ensure_user(
+                email=f"user{index}@{SEED_EMAIL_DOMAIN}",
+                first_name=fake.first_name(),
+                last_name=fake.last_name(),
+                password=password,
+            )
+            for index in range(1, count + 1)
+        ]
+
+    def _ensure_user(
+        self, *, email, first_name, last_name, password, is_superuser=False
+    ):
+        user = User.objects.filter(email=email).first()
+        if user is None:
+            try:
+                user = user_create(
+                    email=email,
+                    password=password,
+                    first_name=first_name,
+                    last_name=last_name,
+                )
+            except ApplicationError as exc:
+                raise CommandError(exc.message) from exc
+        else:
+            user.first_name = first_name
+            user.last_name = last_name
+            user.set_password(password)
+
+        user.is_superuser = is_superuser
+        user.full_clean()
+        user.save()
+        return user
+
+    def _ensure_properties(self, *, count, owners, fake):
+        properties = list(
+            Property.objects.filter(
+                user__email__endswith=SEED_EMAIL_DOMAIN,
+                name__startswith="Seed Property ",
+            ).order_by("id")[:count]
+        )
+        for index in range(len(properties) + 1, count + 1):
+            owner = owners[(index - 1) % len(owners)]
+            property_type = random.choice(PROPERTY_TYPES)
+            bedrooms = random.randint(1, 5) if property_type == "House" else None
+            bathrooms = random.randint(1, 4) if property_type == "House" else None
+            form_data = {
+                "name": f"Seed Property {index}",
+                "description": fake.paragraph(nb_sentences=4),
+                "full_address": fake.address().replace("\n", ", ")[:255],
+                "phone_number": f"+92-{random.randint(3000000000, 3499999999)}",
+                "cnic": (
+                    f"{random.randint(10000, 99999)}-"
+                    f"{random.randint(1000000, 9999999)}-"
+                    f"{random.randint(0, 9)}"
+                ),
+                "property_type": property_type,
+                "price": Decimal(random.randrange(7500000, 75000000, 50000)),
+                "bedrooms": bedrooms,
+                "bathrooms": bathrooms,
+                "area": Decimal(random.randrange(600, 5000)),
+                "documents": None,
+                "is_published": random.random() > 0.15,
+            }
+            images = [
+                self._generate_property_image(property_index=index, image_index=image)
+                for image in range(1, self._images_per_property + 1)
+            ]
+            try:
+                properties.append(
+                    property_create(user=owner, form_data=form_data, images=images)
+                )
+            except ApplicationError as exc:
+                raise CommandError(exc.message) from exc
+        for property_obj in properties:
+            self._ensure_property_images(property_obj=property_obj)
+        return properties
+
+    def _ensure_property_images(self, *, property_obj):
+        existing_count = property_obj.images.count()
+        for image_index in range(existing_count + 1, self._images_per_property + 1):
+            property_image_add(
+                property_obj=property_obj,
+                image_file=self._generate_property_image(
+                    property_index=property_obj.id,
+                    image_index=image_index,
+                ),
+                is_primary=(existing_count == 0 and image_index == 1),
+            )
+
+    def _generate_property_image(self, *, property_index, image_index):
+        width, height = 1200, 800
+        background, accent, secondary = IMAGE_PALETTES[
+            (property_index + image_index) % len(IMAGE_PALETTES)
+        ]
+        image = Image.new("RGB", (width, height), background)
+        draw = ImageDraw.Draw(image)
+
+        horizon = height // 2 + random.randint(-45, 45)
+        draw.rectangle((0, horizon, width, height), fill=(214, 218, 204))
+        draw.rectangle((0, 0, width, horizon), fill=background)
+        draw.polygon(
+            (
+                (220, horizon),
+                (600, 180),
+                (980, horizon),
+            ),
+            fill=accent,
+        )
+        draw.rectangle((315, horizon - 20, 885, 625), fill=(246, 242, 232))
+        draw.rectangle((395, 420, 520, 625), fill=secondary)
+        draw.rectangle((610, 410, 795, 525), fill=(178, 204, 216))
+        draw.rectangle((630, 430, 775, 505), outline=(80, 92, 96), width=6)
+        draw.rectangle((0, 625, width, height), fill=(184, 189, 170))
+
+        buffer = BytesIO()
+        image.save(buffer, format="JPEG", quality=82)
+        buffer.seek(0)
+        return SimpleUploadedFile(
+            name=f"seed-property-{property_index}-{image_index}.jpg",
+            content=buffer.read(),
+            content_type="image/jpeg",
+        )
+
+    def _ensure_favorites(self, *, count, users, properties):
+        if not users or not properties:
+            return 0
+
+        created = 0
+        attempts = 0
+        max_attempts = max(count * 10, 25)
+        while (
+            Favorite.objects.filter(user__email__endswith=SEED_EMAIL_DOMAIN).count()
+            < count
+            and attempts < max_attempts
+        ):
+            attempts += 1
+            user = random.choice(users)
+            property_obj = random.choice(properties)
+            if property_obj.user_id == user.id:
+                continue
+            if Favorite.objects.filter(user=user, property=property_obj).exists():
+                continue
+            favorite_toggle(user=user, property_obj=property_obj)
+            created += 1
+        return created
+
+    def _ensure_conversations(self, *, count, users, properties):
+        if not users or not properties:
+            return []
+
+        conversations = list(
+            Conversation.objects.filter(
+                participant_one__email__endswith=SEED_EMAIL_DOMAIN,
+                participant_two__email__endswith=SEED_EMAIL_DOMAIN,
+            ).order_by("id")[:count]
+        )
+        attempts = 0
+        max_attempts = max(count * 10, 25)
+        while len(conversations) < count and attempts < max_attempts:
+            attempts += 1
+            property_obj = random.choice(properties)
+            candidates = [user for user in users if user.id != property_obj.user_id]
+            if not candidates:
+                continue
+            user = random.choice(candidates)
+            try:
+                conversation = conversation_start(user=user, property_obj=property_obj)
+            except ApplicationError:
+                continue
+            if conversation not in conversations:
+                conversations.append(conversation)
+        return conversations
+
+    def _ensure_messages(self, *, conversations, messages_per_conversation):
+        created = 0
+        for conversation in conversations:
+            existing_count = conversation.messages.count()
+            missing_count = max(0, messages_per_conversation - existing_count)
+            participants = (conversation.participant_one, conversation.participant_two)
+            for index in range(missing_count):
+                sender = participants[(existing_count + index) % 2]
+                content = CHAT_SNIPPETS[(existing_count + index) % len(CHAT_SNIPPETS)]
+                message_create(
+                    conversation=conversation,
+                    sender=sender,
+                    content=content,
+                )
+                created += 1
+            Message.objects.filter(conversation=conversation).exclude(
+                sender=conversation.participant_two
+            ).update(is_read=True)
+        return created

--- a/apps/shared/tests/test_django_integrations.py
+++ b/apps/shared/tests/test_django_integrations.py
@@ -68,7 +68,7 @@ class DjangoIntegrationSettingsTests(SimpleTestCase):
             settings.ACCOUNT_FORMS["signup"], "apps.users.forms.AllauthSignupForm"
         )
         self.assertEqual(
-            settings.ACCOUNT_ADAPTER, "apps.users.adapters.RealmKeyAccountAdapter"
+            settings.ACCOUNT_ADAPTER, "apps.users.adapters.StrataAccountAdapter"
         )
 
     def test_allauth_urls_are_mounted(self):

--- a/apps/shared/tests/test_seed_local_command.py
+++ b/apps/shared/tests/test_seed_local_command.py
@@ -35,9 +35,7 @@ class SeedLocalCommandTests(TestCase):
         )
 
         self.assertIn("Seeded local data", stdout.getvalue())
-        self.assertEqual(
-            User.objects.filter(email__endswith="realmkey.local").count(), 4
-        )
+        self.assertEqual(User.objects.filter(email__endswith="strata.local").count(), 4)
         self.assertEqual(Property.objects.count(), 4)
         self.assertEqual(Favorite.objects.count(), 2)
         self.assertEqual(Conversation.objects.count(), 2)
@@ -67,9 +65,7 @@ class SeedLocalCommandTests(TestCase):
         )
 
         self.assertTrue(User.objects.filter(email="real@example.com").exists())
-        self.assertEqual(
-            User.objects.filter(email__endswith="realmkey.local").count(), 3
-        )
+        self.assertEqual(User.objects.filter(email__endswith="strata.local").count(), 3)
 
     def test_delete_removes_seed_data_without_reseeding(self):
         User.objects.create_user(
@@ -91,7 +87,7 @@ class SeedLocalCommandTests(TestCase):
 
         self.assertIn("Deleted 3 existing seeded user(s).", stdout.getvalue())
         self.assertTrue(User.objects.filter(email="real@example.com").exists())
-        self.assertFalse(User.objects.filter(email__endswith="realmkey.local").exists())
+        self.assertFalse(User.objects.filter(email__endswith="strata.local").exists())
         self.assertFalse(Property.objects.exists())
         self.assertFalse(PropertyImage.objects.exists())
 

--- a/apps/shared/tests/test_seed_local_command.py
+++ b/apps/shared/tests/test_seed_local_command.py
@@ -1,0 +1,103 @@
+from io import StringIO
+from tempfile import TemporaryDirectory
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+
+from apps.chat.models import Conversation, Message
+from apps.properties.models import Favorite, Property, PropertyImage
+
+User = get_user_model()
+
+
+class SeedLocalCommandTests(TestCase):
+    def setUp(self):
+        self.media_root = TemporaryDirectory()
+        self.override = override_settings(MEDIA_ROOT=self.media_root.name)
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.addCleanup(self.media_root.cleanup)
+
+    def test_seeds_local_data(self):
+        stdout = StringIO()
+
+        call_command(
+            "seed_local",
+            users=3,
+            properties=4,
+            favorites=2,
+            conversations=2,
+            messages=2,
+            images=2,
+            stdout=stdout,
+        )
+
+        self.assertIn("Seeded local data", stdout.getvalue())
+        self.assertEqual(
+            User.objects.filter(email__endswith="realmkey.local").count(), 4
+        )
+        self.assertEqual(Property.objects.count(), 4)
+        self.assertEqual(Favorite.objects.count(), 2)
+        self.assertEqual(Conversation.objects.count(), 2)
+        self.assertEqual(Message.objects.count(), 4)
+        self.assertEqual(PropertyImage.objects.count(), 8)
+        self.assertEqual(
+            PropertyImage.objects.filter(is_primary=True).count(),
+            4,
+        )
+
+    def test_reset_only_deletes_seed_users(self):
+        User.objects.create_user(
+            email="real@example.com",
+            password="TestPass1!",
+            first_name="Real",
+            last_name="User",
+        )
+        call_command(
+            "seed_local",
+            users=2,
+            properties=2,
+            conversations=1,
+            messages=1,
+            images=1,
+            reset=True,
+            stdout=StringIO(),
+        )
+
+        self.assertTrue(User.objects.filter(email="real@example.com").exists())
+        self.assertEqual(
+            User.objects.filter(email__endswith="realmkey.local").count(), 3
+        )
+
+    def test_delete_removes_seed_data_without_reseeding(self):
+        User.objects.create_user(
+            email="real@example.com",
+            password="TestPass1!",
+            first_name="Real",
+            last_name="User",
+        )
+        call_command(
+            "seed_local",
+            users=2,
+            properties=2,
+            images=1,
+            stdout=StringIO(),
+        )
+
+        stdout = StringIO()
+        call_command("seed_local", delete=True, stdout=stdout)
+
+        self.assertIn("Deleted 3 existing seeded user(s).", stdout.getvalue())
+        self.assertTrue(User.objects.filter(email="real@example.com").exists())
+        self.assertFalse(User.objects.filter(email__endswith="realmkey.local").exists())
+        self.assertFalse(Property.objects.exists())
+        self.assertFalse(PropertyImage.objects.exists())
+
+    def test_reset_and_delete_cannot_be_combined(self):
+        with self.assertRaisesMessage(
+            CommandError,
+            "Use either --reset or --delete, not both.",
+        ):
+            call_command("seed_local", reset=True, delete=True, stdout=StringIO())

--- a/apps/shared/tests/test_seed_local_command.py
+++ b/apps/shared/tests/test_seed_local_command.py
@@ -1,99 +1,92 @@
-from io import StringIO
-from tempfile import TemporaryDirectory
-
-from django.contrib.auth import get_user_model
 from django.core.management import call_command
-from django.core.management.base import CommandError
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
-from apps.chat.models import Conversation, Message
-from apps.properties.models import Favorite, Property, PropertyImage
-
-User = get_user_model()
+from apps.chat.services import conversation_start, message_create
+from apps.properties.models import Favorite, Property
+from apps.properties.services import favorite_toggle, property_create
+from apps.shared.management.commands.seed_local import (
+    SEED_EMAIL_SUFFIX,
+    seeded_user_queryset,
+)
+from apps.shared.tests.factories import UserFactory
 
 
 class SeedLocalCommandTests(TestCase):
-    def setUp(self):
-        self.media_root = TemporaryDirectory()
-        self.override = override_settings(MEDIA_ROOT=self.media_root.name)
-        self.override.enable()
-        self.addCleanup(self.override.disable)
-        self.addCleanup(self.media_root.cleanup)
+    def test_seeded_user_queryset_matches_only_exact_seed_suffix(self):
+        seeded_user = UserFactory(email=f"user1{SEED_EMAIL_SUFFIX}")
+        lookalike_users = [
+            UserFactory(email="user@notstrata.local"),
+            UserFactory(email="user@dev.strata.local"),
+        ]
 
-    def test_seeds_local_data(self):
-        stdout = StringIO()
+        queryset_ids = set(seeded_user_queryset().values_list("id", flat=True))
 
-        call_command(
-            "seed_local",
-            users=3,
-            properties=4,
-            favorites=2,
-            conversations=2,
-            messages=2,
-            images=2,
-            stdout=stdout,
+        self.assertEqual(queryset_ids, {seeded_user.id})
+        self.assertTrue(all(user.id not in queryset_ids for user in lookalike_users))
+
+    def test_delete_only_removes_exact_seed_users_and_their_related_data(self):
+        seeded_owner = UserFactory(email=f"owner{SEED_EMAIL_SUFFIX}")
+        seeded_guest = UserFactory(email=f"guest{SEED_EMAIL_SUFFIX}")
+        lookalike_owner = UserFactory(email="owner@dev.strata.local")
+        lookalike_guest = UserFactory(email="guest@notstrata.local")
+
+        seeded_property = self._create_property(seeded_owner, "Seeded Listing")
+        lookalike_property = self._create_property(lookalike_owner, "Lookalike Listing")
+
+        favorite_toggle(user=seeded_guest, property_obj=seeded_property)
+        favorite_toggle(user=lookalike_guest, property_obj=lookalike_property)
+
+        seeded_conversation = conversation_start(
+            user=seeded_guest,
+            property_obj=seeded_property,
+        )
+        message_create(
+            conversation=seeded_conversation,
+            sender=seeded_guest,
+            content="seeded message",
         )
 
-        self.assertIn("Seeded local data", stdout.getvalue())
-        self.assertEqual(User.objects.filter(email__endswith="strata.local").count(), 4)
-        self.assertEqual(Property.objects.count(), 4)
-        self.assertEqual(Favorite.objects.count(), 2)
-        self.assertEqual(Conversation.objects.count(), 2)
-        self.assertEqual(Message.objects.count(), 4)
-        self.assertEqual(PropertyImage.objects.count(), 8)
-        self.assertEqual(
-            PropertyImage.objects.filter(is_primary=True).count(),
-            4,
+        lookalike_conversation = conversation_start(
+            user=lookalike_guest,
+            property_obj=lookalike_property,
+        )
+        message_create(
+            conversation=lookalike_conversation,
+            sender=lookalike_guest,
+            content="lookalike message",
         )
 
-    def test_reset_only_deletes_seed_users(self):
-        User.objects.create_user(
-            email="real@example.com",
-            password="TestPass1!",
-            first_name="Real",
-            last_name="User",
+        call_command("seed_local", delete=True)
+
+        self.assertFalse(type(seeded_owner).objects.filter(id=seeded_owner.id).exists())
+        self.assertFalse(type(seeded_guest).objects.filter(id=seeded_guest.id).exists())
+        self.assertTrue(
+            type(lookalike_owner).objects.filter(id=lookalike_owner.id).exists()
         )
-        call_command(
-            "seed_local",
-            users=2,
-            properties=2,
-            conversations=1,
-            messages=1,
-            images=1,
-            reset=True,
-            stdout=StringIO(),
+        self.assertTrue(
+            type(lookalike_guest).objects.filter(id=lookalike_guest.id).exists()
         )
+        self.assertFalse(Property.objects.filter(id=seeded_property.id).exists())
+        self.assertTrue(Property.objects.filter(id=lookalike_property.id).exists())
+        self.assertEqual(Favorite.objects.count(), 1)
+        self.assertEqual(Property.objects.count(), 1)
 
-        self.assertTrue(User.objects.filter(email="real@example.com").exists())
-        self.assertEqual(User.objects.filter(email__endswith="strata.local").count(), 3)
-
-    def test_delete_removes_seed_data_without_reseeding(self):
-        User.objects.create_user(
-            email="real@example.com",
-            password="TestPass1!",
-            first_name="Real",
-            last_name="User",
+    def _create_property(self, user, name):
+        return property_create(
+            user=user,
+            form_data={
+                "name": name,
+                "description": "A nice place",
+                "full_address": "123 Test Street",
+                "phone_number": "+92-3001234567",
+                "cnic": "12345-1234567-1",
+                "property_type": "House",
+                "price": "10000000.00",
+                "bedrooms": 3,
+                "bathrooms": 2,
+                "area": "1200.00",
+                "documents": None,
+                "is_published": True,
+            },
+            images=[],
         )
-        call_command(
-            "seed_local",
-            users=2,
-            properties=2,
-            images=1,
-            stdout=StringIO(),
-        )
-
-        stdout = StringIO()
-        call_command("seed_local", delete=True, stdout=stdout)
-
-        self.assertIn("Deleted 3 existing seeded user(s).", stdout.getvalue())
-        self.assertTrue(User.objects.filter(email="real@example.com").exists())
-        self.assertFalse(User.objects.filter(email__endswith="strata.local").exists())
-        self.assertFalse(Property.objects.exists())
-        self.assertFalse(PropertyImage.objects.exists())
-
-    def test_reset_and_delete_cannot_be_combined(self):
-        with self.assertRaisesMessage(
-            CommandError,
-            "Use either --reset or --delete, not both.",
-        ):
-            call_command("seed_local", reset=True, delete=True, stdout=StringIO())

--- a/apps/users/adapters.py
+++ b/apps/users/adapters.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from apps.shared.validators import validate_password_strength
 
 
-class RealmKeyAccountAdapter(DefaultAccountAdapter):
+class StrataAccountAdapter(DefaultAccountAdapter):
     def clean_password(self, password, user=None):
         default_error = None
         try:

--- a/apps/users/templates/users/login.html
+++ b/apps/users/templates/users/login.html
@@ -1,10 +1,10 @@
 {% extends '_layouts/auth.html' %}
 {% load static %}
 
-{% block title %}Login - RealmKey{% endblock %}
+{% block title %}Login - Strata{% endblock %}
 
 {% block auth_title %}Welcome Back{% endblock %}
-{% block auth_subtitle %}Sign in to your RealmKey account{% endblock %}
+{% block auth_subtitle %}Sign in to your Strata account{% endblock %}
 
 {% block auth_content %}
 {% include 'users/partials/login_form.html' with form=form %}

--- a/apps/users/templates/users/password_change.html
+++ b/apps/users/templates/users/password_change.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/dashboard.html' %}
 {% load static %}
 
-{% block title %}Change Password - RealmKey{% endblock %}
+{% block title %}Change Password - Strata{% endblock %}
 
 {% block page_title %}Change Password{% endblock %}
 

--- a/apps/users/templates/users/profile.html
+++ b/apps/users/templates/users/profile.html
@@ -1,7 +1,7 @@
 {% extends '_layouts/dashboard.html' %}
 {% load static %}
 
-{% block title %}Profile - RealmKey{% endblock %}
+{% block title %}Profile - Strata{% endblock %}
 
 {% block page_title %}My Profile{% endblock %}
 

--- a/apps/users/templates/users/signup.html
+++ b/apps/users/templates/users/signup.html
@@ -1,10 +1,10 @@
 {% extends '_layouts/auth.html' %}
 {% load static %}
 
-{% block title %}Sign Up - RealmKey{% endblock %}
+{% block title %}Sign Up - Strata{% endblock %}
 
 {% block auth_title %}Create Account{% endblock %}
-{% block auth_subtitle %}Join RealmKey and start your property journey{% endblock %}
+{% block auth_subtitle %}Join Strata and start your property journey{% endblock %}
 
 {% block auth_content %}
 {% include 'users/partials/signup_form.html' with form=form %}

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -43,7 +43,7 @@ class SignupView(HTMXMixin, View):
                 )
                 messages.success(
                     request,
-                    f"Welcome to RealmKey, {user.first_name}! Your account has been created successfully.",
+                    f"Welcome to Strata, {user.first_name}! Your account has been created successfully.",
                 )
                 if self.is_htmx:
                     response = HttpResponse()

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -5,11 +5,11 @@
 @source "../../static/js";
 
 @plugin "daisyui" {
-  themes: realmkey --default;
+  themes: strata --default;
 }
 
 @plugin "daisyui/theme" {
-  name: "realmkey";
+  name: "strata";
   default: true;
   prefersdark: false;
   color-scheme: light;

--- a/config/django/local.py
+++ b/config/django/local.py
@@ -11,7 +11,7 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", ["localhost", "127.0.0.1"])  # noqa: F
 CSRF_TRUSTED_ORIGINS = [
     "http://localhost:8000",
     "http://127.0.0.1:8000",
-    "https://realmkey.loca.lt",
+    "https://strata.loca.lt",
 ]
 
 # ============================================================================

--- a/config/django/local.py
+++ b/config/django/local.py
@@ -20,7 +20,6 @@ CSRF_TRUSTED_ORIGINS = [
 
 INSTALLED_APPS += [  # noqa: F405
     "debug_toolbar",
-    "django_extensions",
 ]
 
 MIDDLEWARE.insert(  # noqa: F405

--- a/config/django/production.py
+++ b/config/django/production.py
@@ -11,8 +11,8 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")  # noqa: F405
 CSRF_TRUSTED_ORIGINS = env.list(  # noqa: F405
     "CSRF_TRUSTED_ORIGINS",
     [
-        "https://realmkey.duckdns.org",
-        "http://realmkey.duckdns.org",
+        "https://strata.duckdns.org",
+        "http://strata.duckdns.org",
     ],
 )
 
@@ -76,7 +76,7 @@ EMAIL_PORT = env.int("EMAIL_PORT", 587)  # noqa: F405
 EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", True)  # noqa: F405
 EMAIL_HOST_USER = env.str("EMAIL_HOST_USER", "")  # noqa: F405
 EMAIL_HOST_PASSWORD = env.str("EMAIL_HOST_PASSWORD", "")  # noqa: F405
-DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", "noreply@realmkey.com")  # noqa: F405
+DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", "noreply@strata.com")  # noqa: F405
 
 # ============================================================================
 # ADMIN

--- a/config/settings/__init__.py
+++ b/config/settings/__init__.py
@@ -1,5 +1,5 @@
 """
-Settings package for realm-key project.
+Settings package for strata project.
 
 Import the appropriate settings module based on DJANGO_SETTINGS_MODULE.
 """

--- a/config/settings/allauth.py
+++ b/config/settings/allauth.py
@@ -17,7 +17,7 @@ ACCOUNT_USER_MODEL_EMAIL_FIELD = "email"
 ACCOUNT_EMAIL_VERIFICATION = env.str("ACCOUNT_EMAIL_VERIFICATION", "optional")
 ACCOUNT_SESSION_REMEMBER = None
 ACCOUNT_FORMS = {"signup": "apps.users.forms.AllauthSignupForm"}
-ACCOUNT_ADAPTER = "apps.users.adapters.RealmKeyAccountAdapter"
+ACCOUNT_ADAPTER = "apps.users.adapters.StrataAccountAdapter"
 
 LOGIN_REDIRECT_URL = "properties:list"
 LOGOUT_REDIRECT_URL = "properties:list"

--- a/config/settings/storages.py
+++ b/config/settings/storages.py
@@ -17,8 +17,8 @@ AWS_DEFAULT_ACL = "public-read"
 AWS_S3_VERIFY = env.bool("AWS_S3_VERIFY", True)
 AWS_QUERYSTRING_AUTH = False
 
-AWS_MEDIA_BUCKET_NAME = env.str("AWS_MEDIA_BUCKET_NAME", "realmkey-media")
-AWS_STATIC_BUCKET_NAME = env.str("AWS_STATIC_BUCKET_NAME", "realmkey-static")
+AWS_MEDIA_BUCKET_NAME = env.str("AWS_MEDIA_BUCKET_NAME", "strata-media")
+AWS_STATIC_BUCKET_NAME = env.str("AWS_STATIC_BUCKET_NAME", "strata-static")
 
 STORAGES = {
     "default": {

--- a/config/settings/unfold.py
+++ b/config/settings/unfold.py
@@ -1,8 +1,8 @@
 from django.templatetags.static import static
 
 UNFOLD = {
-    "SITE_TITLE": "RealmKey Admin",
-    "SITE_HEADER": "RealmKey",
+    "SITE_TITLE": "Strata Admin",
+    "SITE_HEADER": "Strata",
     "SHOW_HISTORY": True,
     "SHOW_VIEW_ON_SITE": True,
     "SITE_FAVICONS": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,15 @@ services:
     image: postgres:17-alpine
     container_name: db
     environment:
-      POSTGRES_USER: realmkey
-      POSTGRES_PASSWORD: realmkey
-      POSTGRES_DB: realmkey
+      POSTGRES_USER: strata
+      POSTGRES_PASSWORD: strata
+      POSTGRES_DB: strata
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
       - "5433:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U realmkey"]
+      test: ["CMD-SHELL", "pg_isready -U strata"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-Complete index of all RealmKey documentation.
+Complete index of all Strata documentation.
 
 ## 📖 Main Documentation
 
@@ -104,4 +104,4 @@ See the [Contributing Guide](./guides/contributing.md) for:
 ---
 
 **Last Updated:** February 2026
-**Maintainers:** RealmKey Team
+**Maintainers:** Strata Team

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# RealmKey Documentation
+# Strata Documentation
 
-Welcome to the RealmKey documentation. This directory contains all technical documentation for the project.
+Welcome to the Strata documentation. This directory contains all technical documentation for the project.
 
 ## 📚 Documentation Structure
 

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -1,6 +1,6 @@
 # Frontend Architecture
 
-RealmKey uses a Django-owned frontend pipeline. Django templates remain the page and layout layer, reusable markup lives in Cotton components, Tailwind CSS is built by `django-tailwind-cli`, and browser libraries that do not need local customization are loaded from pinned CDN URLs with SRI.
+Strata uses a Django-owned frontend pipeline. Django templates remain the page and layout layer, reusable markup lives in Cotton components, Tailwind CSS is built by `django-tailwind-cli`, and browser libraries that do not need local customization are loaded from pinned CDN URLs with SRI.
 
 ## Stack
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## System Architecture
 
-RealmKey is a modern Django-based real estate management platform with a component-based architecture.
+Strata is a modern Django-based real estate management platform with a component-based architecture.
 
 ## Technology Stack
 

--- a/docs/deployment/checklist.md
+++ b/docs/deployment/checklist.md
@@ -36,7 +36,7 @@ docker build \
   --build-arg DATABASE_URL=sqlite:///tmp/build.db \
   --build-arg DEBUG=False \
   --build-arg ALLOWED_HOSTS=localhost \
-  -t realm-key:latest .
+  -t strata:latest .
 ```
 
 ### Build Verification
@@ -53,7 +53,7 @@ docker run -p 8000:8000 \
   -e DATABASE_URL=sqlite:///db.sqlite3 \
   -e DEBUG=False \
   -e ALLOWED_HOSTS=localhost \
-  realm-key:latest
+  strata:latest
 ```
 
 - [ ] Container starts successfully
@@ -90,11 +90,11 @@ docker run -p 8000:8000 \
 ### Quick Rollback
 ```bash
 # Revert to previous image
-docker pull realm-key:previous-tag
+docker pull strata:previous-tag
 docker-compose up -d
 
 # Or use orchestration rollback
-kubectl rollout undo deployment/realm-key
+kubectl rollout undo deployment/strata
 ```
 
 ### Database Rollback
@@ -162,13 +162,13 @@ kubectl rollout undo deployment/realm-key
   run: python manage.py collectstatic --noinput
 
 - name: Build Docker Image
-  run: docker build -t realm-key:${{ github.sha }} .
+  run: docker build -t strata:${{ github.sha }} .
 
 - name: Run Tests
-  run: docker run realm-key:${{ github.sha }} pytest
+  run: docker run strata:${{ github.sha }} pytest
 
 - name: Push to Registry
-  run: docker push realm-key:${{ github.sha }}
+  run: docker push strata:${{ github.sha }}
 ```
 
 ### Recommended Tools

--- a/docs/development/chat-client.md
+++ b/docs/development/chat-client.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `ChatClient` class provides a WebSocket-based client for real-time chat functionality in the RealmKey application. It handles connection management, message sending/receiving, and automatic reconnection with exponential backoff.
+The `ChatClient` class provides a WebSocket-based client for real-time chat functionality in the Strata application. It handles connection management, message sending/receiving, and automatic reconnection with exponential backoff.
 
 ## Features
 

--- a/docs/development/frontend-setup.md
+++ b/docs/development/frontend-setup.md
@@ -1,6 +1,6 @@
 # Frontend Development Setup
 
-This guide covers day-to-day UI development in RealmKey.
+This guide covers day-to-day UI development in Strata.
 
 ## Setup
 

--- a/justfile
+++ b/justfile
@@ -36,6 +36,10 @@ makemigrations:
 migrate:
     uv run python manage.py migrate
 
+# Seed local development data
+seed *args:
+    uv run python manage.py seed_local {{args}}
+
 # Install Python dependencies
 build:
     uv sync

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# RealmKey Development Commands
+# Strata Development Commands
 
 # Start development services with Docker
 up:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "realm-key"
+name = "strata"
 version = "0.1.0"
 description = "Django Property Management System"
 requires-python = ">=3.13"

--- a/templates/_components/navigation/footer.html
+++ b/templates/_components/navigation/footer.html
@@ -9,10 +9,10 @@
                     <svg class="w-8 h-8 mr-2 text-primary" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
                     </svg>
-                    <span class="text-xl font-display font-bold">RealmKey</span>
+                    <span class="text-xl font-display font-bold">Strata</span>
                 </div>
                 <p class="text-base-content/70 mb-4 max-w-md">
-                    Discover your perfect property with RealmKey. We make finding and listing properties simple, secure, and enjoyable.
+                    Discover your perfect property with Strata. We make finding and listing properties simple, secure, and enjoyable.
                 </p>
                 <div class="flex space-x-4">
                     <a href="#" class="text-base-content/60 hover:text-primary transition-colors">
@@ -65,7 +65,7 @@
 
         <div class="flex flex-col md:flex-row justify-between items-center">
             <p class="text-base-content/60 text-sm">
-                © {% now "Y" %} RealmKey. All rights reserved.
+                © {% now "Y" %} Strata. All rights reserved.
             </p>
         </div>
     </div>

--- a/templates/_components/navigation/navbar.html
+++ b/templates/_components/navigation/navbar.html
@@ -61,7 +61,7 @@
                 <svg class="w-8 h-8 mr-2" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
                 </svg>
-                RealmKey
+                Strata
             </a>
         </div>
 

--- a/templates/_layouts/auth.html
+++ b/templates/_layouts/auth.html
@@ -12,7 +12,7 @@
                     <c-ui.icon name="home" variant="solid" classes="h-8 w-8 text-base-100" />
                 </div>
                 <h1 class="text-2xl font-display font-bold text-primary">
-                    {% block auth_title %}RealmKey{% endblock %}
+                    {% block auth_title %}Strata{% endblock %}
                 </h1>
                 <p class="text-base-content/60 mt-2">
                     {% block auth_subtitle %}Welcome back{% endblock %}

--- a/templates/_layouts/base.html
+++ b/templates/_layouts/base.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 {% load static tailwind_cli %}
-<html lang="en" data-theme="realmkey">
+<html lang="en" data-theme="strata">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}RealmKey{% endblock %}</title>
+    <title>{% block title %}Strata{% endblock %}</title>
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="{% static 'images/favicon.svg' %}">

--- a/templates/cotton/navigation/footer.html
+++ b/templates/cotton/navigation/footer.html
@@ -7,7 +7,7 @@
             <div class="col-span-1 md:col-span-2">
                 <div class="flex items-center mb-4">
                     <c-ui.icon name="home" variant="solid" classes="h-7 w-7 mr-2 text-secondary-600" />
-                    <span class="text-xl font-display font-bold">RealmKey</span>
+                    <span class="text-xl font-display font-bold">Strata</span>
                 </div>
                 <p class="text-base-content/70 mb-4 max-w-md">
                     List, manage, and discover properties — with direct messaging between owners and interested renters.
@@ -63,7 +63,7 @@
 
         <div class="flex flex-col md:flex-row justify-between items-center">
             <p class="text-base-content/60 text-sm">
-                © {% now "Y" %} RealmKey. All rights reserved.
+                © {% now "Y" %} Strata. All rights reserved.
             </p>
         </div>
     </div>

--- a/templates/cotton/navigation/navbar.html
+++ b/templates/cotton/navigation/navbar.html
@@ -47,7 +47,7 @@
             <!-- Logo -->
             <a href="{% url 'properties:list' %}" class="btn btn-ghost text-xl font-display font-bold text-primary">
                 <c-ui.icon name="home" variant="solid" classes="h-7 w-7 mr-2 text-secondary-600" />
-                RealmKey
+                Strata
             </a>
         </div>
 

--- a/uv.lock
+++ b/uv.lock
@@ -792,7 +792,7 @@ wheels = [
 ]
 
 [[package]]
-name = "realm-key"
+name = "strata"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Description
Adds a `seed_local` Django management command for local testing/demo data. The command seeds demo users, properties, generated property images, favorites, chat conversations, and messages. It supports configurable counts, deterministic fake data, `--reset` to rebuild seed data, and `--delete` to remove seeded data without reseeding.

Also adds a `just seed` recipe that forwards command-line args to the management command.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues
N/A

## Testing
- `DJANGO_SETTINGS_MODULE=config.django.base DATABASE_URL=sqlite:///test.db uv run python manage.py test apps.shared.tests.test_seed_local_command`
  - Passed: 4 tests.
- `uv run ruff check apps/shared/management/commands/seed_local.py apps/shared/tests/test_seed_local_command.py`
  - Passed.
- `uv run ruff format --check apps/shared/management/commands/seed_local.py apps/shared/tests/test_seed_local_command.py`
  - Passed.
- `just --dry-run seed --delete`
  - Verified args forward to `uv run python manage.py seed_local --delete`.

## Screenshots (if applicable)
N/A. No UI/UX changes.

## Checklist
- [x] Code follows style guidelines
- [x] Tests added/updated
- [ ] Documentation updated
- [x] No breaking changes